### PR TITLE
Minor improvement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   DisabledByDefault: true
+  TargetRubyVersion: 2.2
 
 #################### Lint ################################
 

--- a/lib/midori/runner.rb
+++ b/lib/midori/runner.rb
@@ -33,13 +33,15 @@ class Midori::Runner
     @server = TCPServer.new(@bind, @port)
     tfo = @server.tcp_fast_open if Midori::Configure.tcp_fast_open
     @logger.warn 'Failed to use TCP Fast Open feature on your OS'.yellow unless tfo
-    EventLoop.register(@server, :r) do |monitor|
-      socket = monitor.io.accept_nonblock
-      connection = Midori::Connection.new(socket)
-      connection.server_initialize(@api, @logger)
-    end
     async_fiber(Fiber.new do
+      @logger.info 'Midori is booting...'.blue
       @before.call
+      @logger.info 'Midori is serving...'.blue
+      EventLoop.register(@server, :r) do |monitor|
+        socket = monitor.io.accept_nonblock
+        connection = Midori::Connection.new(socket)
+        connection.server_initialize(@api, @logger)
+      end
     end)
     EventLoop.start
     nil

--- a/spec/midori/fixtures/example_api.rb
+++ b/spec/midori/fixtures/example_api.rb
@@ -56,7 +56,7 @@ class ExampleAPI < Midori::API
 
   websocket '/websocket' do |ws|
     ws.on :open do
-      ws.send 'Hello'
+      ws.send ws.connection.request.query_params['param'][0]
     end
 
     ws.on :message do |msg|

--- a/spec/midori/server_spec.rb
+++ b/spec/midori/server_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Midori::Server do
     it 'pass example websocket communication' do
       Timeout::timeout(1) do
         socket = TCPSocket.new '127.0.0.1', 8080
-        socket.print "GET /websocket HTTP/1.1\r\nHost: localhost:8080\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: sGxYzKDBdoC2s8ZImlNgow==\r\n\r\n"
+        socket.print "GET /websocket?param=Hello HTTP/1.1\r\nHost: localhost:8080\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: sGxYzKDBdoC2s8ZImlNgow==\r\n\r\n"
         # Upgrade
         result = Array.new(5) {socket.gets}
         expect(result[0]).to eq("HTTP/1.1 101 Switching Protocols\r\n")


### PR DESCRIPTION
- Set rubocop target version
- Be sure to run `Midori::Configure.before` before running
- Add test to get headers in WebSocket