### PR TITLE
Faster websocket implementation

### DIFF
--- a/ext/midori/websocket.c
+++ b/ext/midori/websocket.c
@@ -1,32 +1,58 @@
 #include <ruby.h>
+#include <ruby/encoding.h>
 
 VALUE Midori = Qnil;
 VALUE MidoriWebSocket = Qnil;
 
 void Init_midori_ext();
 VALUE method_midori_websocket_mask(VALUE self, VALUE payload, VALUE mask);
+VALUE method_midori_websocket_mask_str(VALUE self, VALUE payload, VALUE mask);
 
-void Init_midori_ext() {
+void Init_midori_ext()
+{
   Midori = rb_define_module("Midori");
   MidoriWebSocket = rb_define_class_under(Midori, "WebSocket", rb_cObject);
   rb_define_protected_method(MidoriWebSocket, "mask", method_midori_websocket_mask, 2);
+  rb_define_protected_method(MidoriWebSocket, "mask_str", method_midori_websocket_mask_str, 2);
 }
 
-VALUE method_midori_websocket_mask(VALUE self, VALUE payload, VALUE mask) {
+VALUE method_midori_websocket_mask(VALUE self, VALUE payload, VALUE mask)
+{
   long n = RARRAY_LEN(payload), i, p, m;
   VALUE unmasked = rb_ary_new2(n);
 
   int mask_array[] = {
-    NUM2INT(rb_ary_entry(mask, 0)),
-    NUM2INT(rb_ary_entry(mask, 1)),
-    NUM2INT(rb_ary_entry(mask, 2)),
-    NUM2INT(rb_ary_entry(mask, 3))
-  };
+      NUM2INT(rb_ary_entry(mask, 0)),
+      NUM2INT(rb_ary_entry(mask, 1)),
+      NUM2INT(rb_ary_entry(mask, 2)),
+      NUM2INT(rb_ary_entry(mask, 3))};
 
-  for (i = 0; i < n; i++) {
+  for (i = 0; i < n; i++)
+  {
     p = NUM2INT(rb_ary_entry(payload, i));
     m = mask_array[i % 4];
     rb_ary_store(unmasked, i, INT2NUM(p ^ m));
   }
   return unmasked;
+}
+
+VALUE method_midori_websocket_mask_str(VALUE self, VALUE payload, VALUE mask)
+{
+  long n = RARRAY_LEN(payload), i, p, m;
+  char result[n];
+
+  int mask_array[] = {
+      NUM2INT(rb_ary_entry(mask, 0)),
+      NUM2INT(rb_ary_entry(mask, 1)),
+      NUM2INT(rb_ary_entry(mask, 2)),
+      NUM2INT(rb_ary_entry(mask, 3))};
+
+  for (i = 0; i < n; i++)
+  {
+    p = NUM2INT(rb_ary_entry(payload, i));
+    m = mask_array[i % 4];
+    result[i] = p ^ m;
+  }
+
+  return rb_enc_str_new(result, n, rb_utf8_encoding());
 }

--- a/lib/midori/websocket.rb
+++ b/lib/midori/websocket.rb
@@ -24,7 +24,7 @@ class Midori::WebSocket
     @opcode = byte_tmp & 0b00001111
     # NOT Support Multiple Fragments
     raise Midori::Exception::ContinuousFrame unless fin
-    raise Midori::Exception::OpCodeError unless [0x1, 0x2, 0x8, 0x9, 0xA].include? opcode
+    raise Midori::Exception::OpCodeError unless [0x1, 0x2, 0x8, 0x9, 0xA].include? @opcode
     close if @opcode == 0x8 # Close Frame
     # return if @opcode == 0x9 || @opcode == 0xA # Ping Pong
     decode_mask(data)
@@ -42,8 +42,11 @@ class Midori::WebSocket
     mask = Array.new(4) { data.getbyte }
     # Message
     masked_msg = Array.new(payload) { data.getbyte }
-    @msg = mask(masked_msg, mask)
-    @msg = @msg.pack('C*').force_encoding('utf-8') if [0x1, 0x9, 0xA].include? opcode
+    if [0x1, 0x9, 0xA].include? opcode
+      @msg = mask_str(masked_msg, mask)
+    else # [0x2]
+      @msg = mask(masked_msg, mask)
+    end
     # For debug
     #  data.rewind
     #  data.bytes {|byte| puts byte.to_s(16)}

--- a/spec/midori/websocket_spec.rb
+++ b/spec/midori/websocket_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Midori::WebSocket do
       expect(websocket.msg).to eq('Hello')
     end
 
+    it 'should decode masked Hello Array correctly' do
+      websocket.decode(StringIO.new([0x82, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58].pack('C*')))
+      expect(websocket.msg).to eq([0x48, 0x65, 0x6c, 0x6c, 0x6f])
+    end
+
     it 'should not decode unmasked Hello String' do
       expect do
         websocket.decode(StringIO.new([0x81, 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f].pack('C*')))

--- a/test.rb
+++ b/test.rb
@@ -1,9 +1,0 @@
-require './lib/midori'
-
-class API < Midori::API
-  get '/' do
-    'Hello'
-  end
-end
-
-Midori::Runner.new(API).start


### PR DESCRIPTION
Decode masked string if `opcode` is `[0x1, 0x9, 0xa]` directly instead of returning an array.