### PR TITLE
Fix bug when returning empty body

### DIFF
--- a/lib/midori/response.rb
+++ b/lib/midori/response.rb
@@ -21,7 +21,7 @@ class Midori::Response
   # Generate header string from hash
   # @return [String] generated string
   def generate_header
-    @header['Content-Length'] = @body.bytesize if @header['Content-Length'].nil? && !@body.empty?
+    @header['Content-Length'] = @body.bytesize if @header['Content-Length'].nil?
     @header.map do |key, value|
       "#{key}: #{value}\r\n"
     end.join


### PR DESCRIPTION
```ruby
class TestAPI < Midori::API
  get  '/' do
    ''
  end
end
```

This will return an endless loading when long connection enabled.